### PR TITLE
productsReducer typo error, equal sign needed to be semi colon

### DIFF
--- a/src/client/reducers/productsReducer.js
+++ b/src/client/reducers/productsReducer.js
@@ -3,7 +3,7 @@ import * as types from '../constants/actionTypes';
 const initialState = {
   productsList: [],
   sellersList: [],
-  shoppingList = [],
+  shoppingList: [],
   zip: null,
 };
 


### PR DESCRIPTION
- reducer had typo error, fixed now
- npm start and npm run dev runs successfully